### PR TITLE
ci: fix dependabot auto-merge repo context — set GH_REPO job-wide

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -14,6 +14,10 @@
 # auto-merge. Note: merges performed with GITHUB_TOKEN do not trigger further
 # workflow runs (the push-to-main ci run will not fire for automerges; the
 # PR-side ci run already gated the change).
+#
+# GH_REPO is set job-wide: this workflow never checks out the repo, so gh must
+# not attempt local git-repo discovery (the original failure — "fatal: not a
+# git repository" in gh pr merge).
 
 name: dependabot-automerge
 
@@ -39,6 +43,8 @@ jobs:
       github.event.workflow_run.actor.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    env:
+      GH_REPO: ${{ github.repository }}
     steps:
       - name: Guard — lockfile-only changes + dependencies label
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Dependabot auto-merge failed at the merge step** ("failed to run git: fatal: not a git repository") — the job never checks out the repository, so `gh pr merge` fell back to local git-repo discovery. The `GH_REPO` environment variable is now set job-wide, telling `gh` which repository to operate on without any git context. Guard step unaffected (its `gh api` calls already used explicit paths).
+
 ## [0.4.3] - 2026-08-25
 
 ### Added


### PR DESCRIPTION
- Symptom: automerge run failed at 'gh pr merge' with 'failed to run git: fatal: not a git repository' (run 32869033284 on PR #15); the workflow never checks out the repository, and without git context gh falls back to local git-repo discovery, which cannot work in a checkout-less job
- Fix: job-level GH_REPO: github.repository env — gh's documented override (source: cli/cli repo_override.go) that skips git detection for all gh invocations in the job
- Guard step unchanged (its gh api calls use explicit repos/ paths and succeeded in the failed run); no step-level env shadowing (validated)
- CHANGELOG [Unreleased] Fixed entry added