### PR TITLE
fix(ranalysis): absolute paths for locfit docker volume mounts

### DIFF
--- a/scripts/ranalysis/build-locfit.sh
+++ b/scripts/ranalysis/build-locfit.sh
@@ -10,13 +10,13 @@
 set -euo pipefail
 
 OUT_DIR="${1:?usage: build-locfit.sh <output-dir> [version]}"
+mkdir -p "${OUT_DIR}"
+OUT_DIR="$(cd "${OUT_DIR}" && pwd -P)"
 LOCfit_VERSION="${2:-1.5-9.12}"
 IMAGE="${LOCfit_IMAGE:-ghcr.io/r-wasm/webr@sha256:2bd309d7a4ea1daed82b6fdb8e325b0de715fcd8592c5b6f3b3b88366e70cb76}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORK_DIR="$(mktemp -d)"
 trap 'rm -rf "${WORK_DIR}"' EXIT
-
-mkdir -p "${OUT_DIR}"
 
 curl -fsSL --retry 3 --max-time 120 \
   "https://cran.r-project.org/src/contrib/locfit_${LOCfit_VERSION}.tar.gz" \

--- a/scripts/ranalysis/fetch-mirror.mjs
+++ b/scripts/ranalysis/fetch-mirror.mjs
@@ -11,7 +11,7 @@ import {
   mkdirSync, writeFileSync, existsSync, statSync, readFileSync, copyFileSync, rmSync,
 } from 'node:fs';
 import { createHash } from 'node:crypto';
-import { join, relative } from 'node:path';
+import { join, relative, resolve } from 'node:path';
 
 const log = (...a) => console.log(`[${new Date().toISOString().slice(11, 19)}]`, ...a);
 const sh = (cmd) => {
@@ -129,7 +129,7 @@ if (!existsSync(locfitTgz)) {
     log(`copied locfit from ${args.locfitTgz}`);
   } else if (!args.skipLocfitBuild) {
     log('building locfit via docker (rwasm)...');
-    const r = spawnSync('bash', [join(process.cwd(), 'scripts', 'ranalysis', 'build-locfit.sh'), contribDir], {
+    const r = spawnSync('bash', [join(process.cwd(), 'scripts', 'ranalysis', 'build-locfit.sh'), resolve(contribDir)], {
       stdio: 'inherit',
     });
     if (r.status !== 0 || !existsSync(locfitTgz)) throw new Error('locfit docker build failed');


### PR DESCRIPTION
The first release run failed: fetch-mirror.mjs passed the relative contribDir (mirror-out/repo/bin/...) to build-locfit.sh, and docker -v interprets a relative host path as a volume NAME, rejecting the slashes (invalid characters for a local volume name).

- build-locfit.sh normalizes OUT_DIR to a physical absolute path right after mkdir (pwd -P), making every caller invocation shape safe and removing the now-redundant later mkdir
- fetch-mirror.mjs passes resolve(contribDir) explicitly

Verified: origin/main script reproduces the exact runner error with a relative out dir; fixed script builds locfit_1.5-9.12.tgz through docker with both relative and absolute invocations; full CI-path replay (fetch-mirror without --locfit-tgz from a relative --out, docker locfit build, closure download, PACKAGES regeneration, 61.9 MB bundle) passes; validate-bundle 11/11 golden checks green on the produced bundle; unit suite and typecheck unchanged-green