### PR TITLE
fix(ranalysis): proxy-aware mirror downloads; 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-08-27
+
+### Fixed
+
+- **R analysis: proxy-aware mirror downloads** — the wasm bundle downloader now
+  installs the repo's proxy-aware global fetch dispatcher (side-effect import of
+  `connections/proxy.js`) so hosts behind HTTP(S)_PROXY can download the release
+  asset at all (verified live: GitHub release download via direct undici fetch
+  stalls and dies with `SocketError` on such hosts; through the proxy the same
+  62 MB transfer completes in ~5 s). Affects standalone/re-implementation use of
+  the ranalysis path; bundled-server users already got the dispatcher from other
+  tool modules.
+
 ## [0.5.0] - 2026-08-27
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "biomcp",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "biomcp",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "^8.10.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "biomcp",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "BioMCP - Biomedical MCP Server in TypeScript",
   "type": "module",
   "main": "dist/bundle.js",

--- a/src/ranalysis/mirror.ts
+++ b/src/ranalysis/mirror.ts
@@ -1,3 +1,4 @@
+import '../connections/proxy.js';
 import { createHash } from 'node:crypto';
 import { createServer, type Server } from 'node:http';
 import { createReadStream, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '0.5.0';
+export const VERSION = '0.5.1';


### PR DESCRIPTION
- src/ranalysis/mirror.ts imports connections/proxy.js for its side effect so the wasm bundle downloader honors HTTP(S)_PROXY even when used standalone: verified live on a proxied host where direct undici fetch to github.com release assets stalls and resets after ~90s while the proxied download completes 62 MB in ~5 s
- Phase 3 default-path e2e now fully green against the published v0.5.0 release: releases/latest resolution, GitHub-reported digest match, 62 MB download, manifest verification, per-file integrity, webR bootstrap, digest-skip warm boots (6.4s), and real DESeq2 runs