### PR TITLE
docs(release): harden MCP Registry publish path (publisher >= 1.1.0, token hygiene)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,10 @@ dist
 scripts/external-databases/*/raw/
 opencode.jsonc
 
+# mcp-publisher local auth artifacts (never commit — live tokens)
+.mcpregistry_github_token
+.mcpregistry_registry_token
+.mcp_publisher_token
+
 # local-only development plan docs (never committed/pushed)
 docs/development/*-PLAN.md

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -25,10 +25,20 @@ this document encodes *order*.
    `npm pack --dry-run` (expect dist/bundle.js + dist/cli.js, no extras) →
    `npm publish` (`--otp=<code>` if 2FA-forced). Never re-publish a version
    already on npm — duplicate versions are rejected permanently.
-10. MCP Registry: `mcp-publisher publish` at repo root (login first with
-    `mcp-publisher login github` if the token expired). If publish fails after
-    step 9, fix `server.json` on main and re-run **`mcp-publisher publish`
-    only** — never npm.
+10. MCP Registry — from repo root, with `mcp-publisher` **≥ 1.1.0** (v1.0.0
+    mangles the publish payload → 422 `registryType`/`registry_type`,
+    modelcontextprotocol/registry#525/#560). Check `mcp-publisher --version`;
+    update via `brew upgrade mcp-publisher` or the quickstart curl (installs
+    to `/usr/local/bin`; run it from outside the repo), then `hash -r`.
+    After any upgrade **re-login**: `mcp-publisher login github` — 1.x reads
+    only `~/.config/mcp-publisher/token.json`; v1.0.0-era tokens
+    (`~/.mcp_publisher_token`, `.mcpregistry_*` in the cwd) are invisible to
+    it — purge them (`rm -f .mcpregistry_* ~/.mcp_publisher_token`). Always
+    `mcp-publisher validate` before `publish` (networked, auth-free; expect
+    "✅ server.json is valid"). Never run `mcp-publisher init` in the repo —
+    the committed `server.json` is the source of truth. If publish fails
+    after step 9, fix `server.json` on main and re-run
+    **`mcp-publisher publish` only** — never npm.
 11. Context7 refreshes from GitHub `main` automatically after the first
     submission (context7.com/add-library); submit or refresh only after the
     release commit is merged, so indexed doc pins are current.


### PR DESCRIPTION
## Why

The v0.9.0 registry publish failed with 422 `registryType`/`registry_type` — root-caused to the **mcp-publisher v1.0.0 schema-transformation bug** (modelcontextprotocol/registry#523/#525/#550/#560; fixed in v1.1.0). The repo's `server.json` was verified valid against the live registry with publisher 1.8.1 (`validate` → ✅). No repo artifact was wrong; this PR hardens the process so the failure class can't recur or leak credentials.

## Changes

- `.gitignore`: exclude mcp-publisher auth artifacts (`.mcpregistry_github_token`, `.mcpregistry_registry_token`, `.mcp_publisher_token`) — live tokens written to the repo root by v1.0.0-era login flows were un-ignored; one `git add -A` away from leaking
- `docs/RELEASE.md` step 10 rewritten: publisher ≥ 1.1.0 floor (+ bug refs), upgrade commands (`brew upgrade` / quickstart curl from outside the repo, `hash -r`), **mandatory re-login after any upgrade** (1.x reads only `~/.config/mcp-publisher/token.json`; v1.0-era tokens invisible), `validate` before `publish` (auth-free), never `init` in-repo; npm-immutability rule retained

## Verification

- `git check-ignore` confirms both token files are now ignored; `git status` clean of them
- config drift-guard tests green (docs-only change)

## After merge

Re-run the fixed publish sequence (see RELEASE.md step 10): upgrade publisher → re-login → `validate` → `publish` → verify via the registry search API.