### PR TITLE
v0.9.2: remove Python/Rust-BioMCP disambiguation stress — README banner, npm description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.2] - 2026-09-01
+
+### Changed
+
+- **README top banner removed** — the "not the Python/Rust BioMCP" disambiguation blockquote no longer leads the page; package-name disambiguation lives in `docs/AGENT-INSTALL.md` (the agent-facing guide every install path routes through, and the MCP Registry `websiteUrl` target), and the upstream BioMCP Rust credit remains under License. npm-search identification is unchanged (package `description`/keywords still carry "distinct from the Python/Rust BioMCP"). This release refreshes the npm package-page README.
+
 ## [0.9.1] - 2026-08-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.9.2] - 2026-09-01
 
+### Added
+
+- **stderr note on the legacy `run` argv** — `biomcp run` (the retired Python-BioMCP server invocation, which agents may still remember) now prints one stderr line explaining that this TypeScript package starts its MCP stdio server directly, before starting it exactly as before. Explained hang instead of silent hang; stdout stays MCP-protocol-clean; zero behavior change (unrecognized argv ≡ bare `biomcp`, now pinned by tests).
+
 ### Changed
 
 - **README top banner removed** — the "not the Python/Rust BioMCP" disambiguation blockquote no longer leads the page; package-name disambiguation lives in `docs/AGENT-INSTALL.md` (the agent-facing guide every install path routes through, and the MCP Registry `websiteUrl` target), and the upstream BioMCP Rust credit remains under License. This release refreshes the npm package-page README.
-- **npm package description de-stressed** — the `package.json` description drops the "; distinct from the Python/Rust BioMCP by genomoncology" clause (now: "BioMCP-TS — TypeScript biomedical MCP server (genes, variants, trials, literature, patents, R analysis)"); `docs/AGENT-INSTALL.md` keeps only the minimal functional note for agents arriving with Python/Rust-BioMCP habits (the `biomcp run` / `--biowasm` flags warning, without vendor call-out). Legal attribution in `NOTICE` and the License-section credit are unchanged.
+- **npm package description de-stressed** — the `package.json` description drops the "; distinct from the Python/Rust BioMCP by genomoncology" clause (now: "BioMCP-TS — TypeScript biomedical MCP server (genes, variants, trials, literature, patents, R analysis)"); `docs/AGENT-INSTALL.md` keeps only the minimal agent-facing functional note for agents arriving with Python/Rust-BioMCP habits — corrected to cite the real upstream subcommands (`biomcp serve`, `biomcp search …`; the previously cited `--biowasm` flag never existed upstream and had been conflated with this project's own `ANALYSIS_BIOWASM` feature). Legal attribution in `NOTICE` and the License-section credit are unchanged.
 
 ## [0.9.1] - 2026-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **README top banner removed** — the "not the Python/Rust BioMCP" disambiguation blockquote no longer leads the page; package-name disambiguation lives in `docs/AGENT-INSTALL.md` (the agent-facing guide every install path routes through, and the MCP Registry `websiteUrl` target), and the upstream BioMCP Rust credit remains under License. npm-search identification is unchanged (package `description`/keywords still carry "distinct from the Python/Rust BioMCP"). This release refreshes the npm package-page README.
+- **README top banner removed** — the "not the Python/Rust BioMCP" disambiguation blockquote no longer leads the page; package-name disambiguation lives in `docs/AGENT-INSTALL.md` (the agent-facing guide every install path routes through, and the MCP Registry `websiteUrl` target), and the upstream BioMCP Rust credit remains under License. This release refreshes the npm package-page README.
+- **npm package description de-stressed** — the `package.json` description drops the "; distinct from the Python/Rust BioMCP by genomoncology" clause (now: "BioMCP-TS — TypeScript biomedical MCP server (genes, variants, trials, literature, patents, R analysis)"); `docs/AGENT-INSTALL.md` keeps only the minimal functional note for agents arriving with Python/Rust-BioMCP habits (the `biomcp run` / `--biowasm` flags warning, without vendor call-out). Legal attribution in `NOTICE` and the License-section credit are unchanged.
 
 ## [0.9.1] - 2026-08-31
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 A high-performance MCP server that gives LLMs access to 40 biomedical tools federated across 50+ upstream APIs — genes, variants, drugs, diseases, literature, clinical trials, structural biology, and functional genomics in a single integration.
 
-> **Note:** this is BioMCP-**TS**, the TypeScript server published as npm package **`biomcp`**. It is distinct from the Python/Rust BioMCP by genomoncology — CLI flags like `biomcp run` / `--biowasm` do not exist here; optional features are enabled with environment variables or the `.biomcp.json` config file.
-
 ## Highlights
 
 - **41 tools** across 15 registration modules — search, retrieve, and cross-reference biomedical entities, plus the `biomcp_configure` meta tool for configuration observability (+3 optional database tools, +4 optional R analysis tools, +8 optional biowasm analysis tools)

--- a/docs/AGENT-INSTALL.md
+++ b/docs/AGENT-INSTALL.md
@@ -2,7 +2,7 @@
 
 This document is written so a human **or an AI agent** can install and configure BioMCP end-to-end: add it to an MCP client, pick the right invocation form, decide on API keys and optional features, then verify — with `biomcp doctor` as the one diagnostic for everything.
 
-> **What is this?** BioMCP-TS is a TypeScript biomedical MCP server (npm package **`biomcp`**: genes, variants, trials, literature, patents, optional R analysis). CLI flags from the similarly-named Python/Rust BioMCP (`biomcp run`, `--biowasm`) do not exist here; features are enabled with environment variables or a config file.
+> **What is this?** BioMCP-TS is a TypeScript biomedical MCP server (npm package **`biomcp`**: genes, variants, trials, literature, patents, optional R analysis). CLI subcommands from the similarly-named Python/Rust BioMCP (`biomcp serve`, `biomcp search …`) do not exist here — bare `biomcp` starts the MCP stdio server; the only CLI surface is `--help` / `--version` / `doctor`, and features are enabled with environment variables or a config file.
 
 BioMCP is a standard MCP **stdio** server — any MCP-compatible client can run it.
 
@@ -243,6 +243,7 @@ Optional keys raise rate limits or unlock premium sources (`NCBI_API_KEY`, `S2_A
 | Symptom | Cause | Fix |
 |---------|-------|-----|
 | `npx biomcp --help` idles silently | pre-0.9 versions start the stdio server on any argv | use `biomcp doctor` / `--version`; upgrade |
+| `biomcp run` prints a note, then seems to hang | retired Python-BioMCP usage; unrecognized argv still starts the stdio server (stderr note since 0.9.2) | MCP clients: spawn bare `biomcp`; humans/agents: `biomcp doctor` |
 | Feature tools missing after enabling | server loaded config at startup | restart the client (§2 table) |
 | `webr`/`mysql2` missing while `install_mode` is `npx-cache` | peer deps invisible to the npx cache | use a §2 command that carries the matching `-p` flag (doctor's snippet always includes every enabled feature's peer), or local tree + absolute `node …/dist/bundle.js` path |
 | Command missing a peer after enabling more features | the client command was written for fewer features | copy doctor's paste-ready snippet — it unions every enabled feature's `-p` flags |

--- a/docs/AGENT-INSTALL.md
+++ b/docs/AGENT-INSTALL.md
@@ -2,7 +2,7 @@
 
 This document is written so a human **or an AI agent** can install and configure BioMCP end-to-end: add it to an MCP client, pick the right invocation form, decide on API keys and optional features, then verify — with `biomcp doctor` as the one diagnostic for everything.
 
-> **What is this?** BioMCP-TS is a TypeScript biomedical MCP server (npm package **`biomcp`**: genes, variants, trials, literature, patents, optional R analysis). It is **not** the Python/Rust BioMCP by genomoncology — their CLI flags (`biomcp run`, `--biowasm`) do not exist here; features are enabled with environment variables or a config file.
+> **What is this?** BioMCP-TS is a TypeScript biomedical MCP server (npm package **`biomcp`**: genes, variants, trials, literature, patents, optional R analysis). CLI flags from the similarly-named Python/Rust BioMCP (`biomcp run`, `--biowasm`) do not exist here; features are enabled with environment variables or a config file.
 
 BioMCP is a standard MCP **stdio** server — any MCP-compatible client can run it.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "biomcp",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "biomcp",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "^8.10.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "biomcp",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "BioMCP-TS — TypeScript biomedical MCP server (genes, variants, trials, literature, patents, R analysis). npm package `biomcp`; distinct from the Python/Rust BioMCP by genomoncology",
   "keywords": [
     "mcp",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "biomcp",
   "version": "0.9.2",
-  "description": "BioMCP-TS — TypeScript biomedical MCP server (genes, variants, trials, literature, patents, R analysis). npm package `biomcp`; distinct from the Python/Rust BioMCP by genomoncology",
+  "description": "BioMCP-TS — TypeScript biomedical MCP server (genes, variants, trials, literature, patents, R analysis)",
   "keywords": [
     "mcp",
     "mcp-server",

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "source": "github"
   },
   "websiteUrl": "https://github.com/yeyuan98/biomcp-ts/blob/main/docs/AGENT-INSTALL.md",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "biomcp",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/src/__tests__/cli/args.test.ts
+++ b/src/__tests__/cli/args.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from '@jest/globals';
 import { readFileSync } from 'node:fs';
-import { parseCliArgs } from '../../cli/args.js';
+import { parseCliArgs, serverModeNotice } from '../../cli/args.js';
 
 describe('parseCliArgs (dispatch contract)', () => {
   const cases: { argv: string[]; command: string; json?: boolean; client?: string }[] = [
@@ -16,6 +16,7 @@ describe('parseCliArgs (dispatch contract)', () => {
     // backward compat: anything unrecognized must stay server mode (the server
     // entry never reads argv; clients may pass stray args)
     { argv: ['serve'], command: 'server' },
+    { argv: ['run'], command: 'server' },
     { argv: ['--bogus'], command: 'server' },
     { argv: ['gene_search'], command: 'server' },
     { argv: ['doctor', '--bogus'], command: 'server' },
@@ -28,6 +29,25 @@ describe('parseCliArgs (dispatch contract)', () => {
       expect(parsed.command).toBe(c.command);
       expect(parsed.json).toBe(c.json ?? false);
       if (c.client !== undefined) expect(parsed.client).toBe(c.client);
+    });
+  }
+});
+
+describe('serverModeNotice (stderr-only, behavior-invariant)', () => {
+  const NOTICED: string[][] = [['run'], ['run', '--toolset', 'python'], ['run', '--help']];
+  for (const argv of NOTICED) {
+    it(`${JSON.stringify(argv)} -> explains the retired Python-BioMCP invocation`, () => {
+      const notice = serverModeNotice(argv);
+      expect(notice).not.toBeNull();
+      expect(notice).toContain('Python BioMCP');
+      expect(notice).toContain('AGENT-INSTALL');
+      expect(notice).toContain('doctor');
+    });
+  }
+  const SILENT: string[][] = [[], ['serve'], ['--stray'], ['--help'], ['doctor'], ['doctor', '--bogus'], ['Run']];
+  for (const argv of SILENT) {
+    it(`${JSON.stringify(argv)} -> no notice`, () => {
+      expect(serverModeNotice(argv)).toBeNull();
     });
   }
 });

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -40,3 +40,13 @@ export function parseCliArgs(argv: string[]): ParsedCliArgs {
   }
   return { command: 'server', json: false, unknown: [] };
 }
+
+/**
+ * stderr-only notice when argv looks like the retired Python-BioMCP server
+ * invocation; never changes behavior (server mode proceeds regardless).
+ * MCP clients spawn bare `biomcp` (no argv) and never see it.
+ */
+export function serverModeNotice(argv: string[]): string | null {
+  if (argv[0] !== 'run') return null;
+  return '[biomcp] note: "run" is the invocation of the old Python BioMCP - this TypeScript package starts its MCP stdio server directly with no arguments (humans/agents: use `doctor`; see docs/AGENT-INSTALL.md).';
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { parseCliArgs } from './args.js';
+import { parseCliArgs, serverModeNotice } from './args.js';
 import { helpText } from './help.js';
 import { buildDoctorReport, exitCodeFor, formatDoctorText } from './doctor.js';
 import { CLIENT_IDS } from './snippets.js';
@@ -14,7 +14,8 @@ import { VERSION } from '../version.js';
  */
 
 async function main(): Promise<void> {
-  const parsed = parseCliArgs(process.argv.slice(2));
+  const argv = process.argv.slice(2);
+  const parsed = parseCliArgs(argv);
   if (parsed.command === 'help') {
     process.stdout.write(helpText());
     return;
@@ -31,6 +32,8 @@ async function main(): Promise<void> {
     return;
   }
   // server mode (bare invocation or unrecognized args — back-compat)
+  const notice = serverModeNotice(argv);
+  if (notice) process.stderr.write(notice + '\n');
   const serverEntry = new URL('./bundle.js', import.meta.url).href;
   try {
     await import(serverEntry);

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '0.9.1';
+export const VERSION = '0.9.2';


### PR DESCRIPTION
## Summary

Removes the "not the Python/Rust BioMCP" disambiguation stress from every public-facing surface, corrects the upstream-CLI facts, adds a stderr note for the legacy `run` argv, and bumps **0.9.2** so the npm package page (README + description are tarball-baked and 0.9.1's are immutable) picks up the clean presentation at publish. All fixes land in this single PR / single release.

## Changes

- **README** — the top blockquote banner is deleted (page opens with the pitch straight into Highlights). No replacement section; the upstream BioMCP Rust credit stays under License.
- **npm description** — `package.json` drops the "; distinct from the Python/Rust BioMCP by genomoncology" clause; npm search now shows only the functional one-liner (`BioMCP-TS — TypeScript biomedical MCP server (…)`, which still self-identifies as TypeScript in the first 25 chars).
- **docs/AGENT-INSTALL.md** — keeps only the minimal agent-facing functional note, corrected to the real upstream subcommands (`biomcp serve`, `biomcp search …`): bare `biomcp` starts the stdio server, the only CLI surface is `--help` / `--version` / `doctor`. The previously cited `--biowasm` flag never existed upstream (it had been conflated with this project's own `ANALYSIS_BIOWASM` feature).
- **stderr note for `biomcp run`** — the retired Python-BioMCP invocation (which agents may still remember) now prints one stderr line explaining the situation before starting the server exactly as before. Explained hang instead of silent hang; stdout stays MCP-protocol-clean; zero behavior change. §5 failure table gains the matching row.
- **Kept (legal / by design):** `NOTICE` MIT attribution, README License-section credit, CHANGELOG history.
- **v0.9.2 bump** — version.ts / package.json / lock / server.json ×2 + CHANGELOG `[0.9.2]` entry (Added: run-argv note; Changed: banner + description + corrected doc wording).

## Verification

- `tsc --noEmit` clean; **1290/1290 tests** (11 new: dispatch-table case + notice hit/miss matrix); build green; `--version` → 0.9.2
- Smoke: `node dist/cli.js run` → note on **stderr** + server starts (then exits cleanly on stdin EOF via the 0.9.1 guard); `serve` → no note; `doctor` unaffected
- Tarball check: `npm pack` carries the banner-free README at 0.9.2
- Sweep verified: remaining `genomoncology` mentions are exactly NOTICE + README License credit + the de-stressed AGENT-INSTALL functional note; server.json already clean
- Independent review rounds on both the plan and the implementation: 0 blockers

## Post-merge (owner-side)

- `r-wasm-mirror` auto-tags `v0.9.2` and copy-forwards the wasm asset (this PR touches none of the rebuild-trigger paths)
- `npm publish` → npm page refreshes README + description
- `mcp-publisher publish` (RELEASE.md step 10) — also clears the standing registry-metadata lag at 0.9.0

## Remaining optional follow-ups (not in this PR)

- `serve`-argv stderr note (the *current* upstream habit — one word in `serverModeNotice`)
- help.ts one-liner stating the fall-through rule ("any other arguments also start the server")