### PR TITLE
fix(ci): stats-badges — commit before pull to keep dirty-worktree safe

### DIFF
--- a/.github/workflows/stats-badges.yml
+++ b/.github/workflows/stats-badges.yml
@@ -20,6 +20,9 @@ concurrency:
 
 jobs:
   update:
+    # workflow_dispatch can target any ref; only ever act on main so a
+    # branch-selected dispatch can never push that branch's commits to main
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/stats-badges.yml
+++ b/.github/workflows/stats-badges.yml
@@ -50,22 +50,22 @@ jobs:
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .github/badges/stats.json
+          if git diff --cached --quiet -- .github/badges/stats.json; then
+            echo "stats unchanged; nothing to commit"
+            exit 0
+          fi
           ytd=$(jq -r .ytd .github/badges/stats.json)
           commits30d=$(jq -r .commits30d .github/badges/stats.json)
-          for attempt in 1 2 3; do
-            git pull --rebase origin main
-            if git diff --quiet HEAD -- .github/badges/stats.json; then
-              echo "stats unchanged; nothing to commit"
-              exit 0
-            fi
-            git add .github/badges/stats.json
-            git commit -m "chore(badges): refresh stats [skip ci]" \
-              -m "- npm downloads YTD: $ytd
+          git commit -m "chore(badges): refresh stats [skip ci]" \
+            -m "- npm downloads YTD: $ytd
           - commits (rolling 30d, bot-excluded): $commits30d"
+          for attempt in 1 2 3; do
             if git push origin HEAD:main; then
               exit 0
             fi
-            echo "push attempt $attempt failed (race); retrying"
+            echo "push attempt $attempt failed (race); rebasing and retrying"
+            git pull --rebase origin main
             sleep 5
           done
           echo "push failed after 3 attempts"


### PR DESCRIPTION
## Root cause (run 33781251674)
The retry loop ran `git pull --rebase` **before** committing; git refuses to rebase with the unstaged `stats.json` the compute step just wrote → exit 128 before any commit/push.

## Fix
Reorder: `add` → staged-diff skip-if-unchanged check → `commit` → `push`; `git pull --rebase` now only runs after a rejected push (clean tree by then). Race-retry semantics and `[skip ci]` unchanged.

## Sandbox validation (exact shipped step script, /tmp bare-origin simulation)
- normal update: commit + push ✓
- unchanged values: `stats unchanged; nothing to commit`, exit 0, no commit ✓
- true race: interloper advances origin → push rejected → rebase → push succeeds; concurrent commit preserved in final history (no drop) ✓
- production bug scenario (unstaged stats.json): handled — no pull before commit ✓
- actionlint 1.7.12: PASS

Post-merge: re-run `workflow_dispatch` — expect green run and stats.json → ytd current / commits30d 158.